### PR TITLE
Ip resolve cache + fork elimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ Extension tries its best to deliver trace to the agent.
 And if the trace's size overflows UDP package - we split spans into several copies and flush them one by one so that you'll get multiple identical spans with
 a sequential set of logs.
 
+
+## php.ini settings
+
+jaeger-client.ip_revalidate_freq = seconds (default 0)
+
+Caches ip address and hostname values for specified interval to reduce calls
+to detect them.
+
 ## Building for PHP 7.4
 
 1. clone from master (php-cpp will have tag 2.3.0)

--- a/src/Helper.h
+++ b/src/Helper.h
@@ -29,6 +29,8 @@ namespace OpenTracing
         static const int timeOfDayMicroSec(int64_t& microsec);
         /*Get current unix timestamp in microseconds based on clock_gettime() output*/
         static const int clockGetTimeMicroSec(int64_t& microsec);
+        /*Get current ip fallback*/
+        static const std::string getCurrentIpFallback();
     public:
         /*Get current unix timestamp in microseconds*/
         static const TimeStamp now();

--- a/src/Process.cpp
+++ b/src/Process.cpp
@@ -1,9 +1,14 @@
 #include <iostream>
+#include <time.h>
 #include "Process.h"
 #include "Helper.h"
 #include "Tracer.h"
 
 const std::string OpenTracing::Process::DEFAULT_SERVICE_NAME{ "unknown" };
+
+int OpenTracing::Process::ip_timestamp = 0;
+std::string OpenTracing::Process::ip;
+std::string OpenTracing::Process::hostname;
 
 OpenTracing::Process::Process(const std::string& serviceName) :
     _serviceName{ serviceName }
@@ -13,8 +18,18 @@ OpenTracing::Process::Process(const std::string& serviceName) :
         ss << this;
         Tracer::file_logger.PrintLine("\tProcess " + ss.str() + " constructor", true);
     }
-    _tags.push_back(new Tag(Tag::TAG_TYPE_HOST, Helper::getHostName()));
-    _tags.push_back(new Tag(Tag::TAG_TYPE_IP, Helper::getCurrentIp()));
+
+    time_t now = time(NULL);
+
+    int ip_revalidate_freq = Php::ini_get("jaeger-client.ip_revalidate_freq");
+
+    if (ip_revalidate_freq <= 0 || ip_timestamp + ip_revalidate_freq <= now || ip.empty()) {
+        ip = Helper::getCurrentIp();
+        hostname = Helper::getHostName();
+        ip_timestamp = now;
+    }
+    _tags.push_back(new Tag(Tag::TAG_TYPE_HOST, hostname));
+    _tags.push_back(new Tag(Tag::TAG_TYPE_IP, ip));
 }
 
 OpenTracing::Process::~Process()

--- a/src/Process.h
+++ b/src/Process.h
@@ -16,6 +16,10 @@ namespace OpenTracing
         Process(const std::string& serviceName);
         Process(const Process&) = delete;
         ~Process();
+    private:
+        static int ip_timestamp;
+        static std::string ip;
+        static std::string hostname;
     };
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,12 +24,14 @@ extern "C" {
     {
         // static(!) Php::Extension object that should stay in memory
         // for the entire duration of the process (that's why it's static)
-        static Php::Extension extension("jaeger-client", "1.11");
+        static Php::Extension extension("jaeger-client", "1.12");
 
         //extension.onStartup(&onStartup);
         //extension.onRequest(&onRequest);
         extension.onIdle(&onIdle);
         extension.onShutdown(&onShutDown);
+
+        extension.add(Php::Ini("jaeger-client.ip_revalidate_freq", 0));
 
         //export Tracer
         Php::Class<Tracer> TracerClass("Tracer");


### PR DESCRIPTION
My tests showed that on small requests a lot of time spent on forking hostname shell command.
There are two commits
1) eliminate forks (use ver3 resolver code, that now works) - still takes ~1,5ms to talk to kernel
2) add ini setting to cache resolve results between requests - with always resolve as default